### PR TITLE
Emit zone intermediates via output_path; harmonise zone-function API (0.4.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: elsar
 Title: Functions and Tools For Creating ELSA Data Stacks
-Version: 0.3.1
+Version: 0.4.0
 Authors@R: 
     c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,59 @@
+# elsar 0.4.0
+
+## Breaking Changes
+
+* Zone-function parameters were harmonised for a coherent API. The human-pressure
+  input is now `human_pressure` everywhere (was `hii_input` in
+  `make_protect_zone()`, `make_manage_zone()`, `make_degraded_areas()`); raw
+  input rasters use bare names without the `_input` suffix
+  (`agricultural_areas`, `built_areas`, `pasturelands`, `managed_forests` -
+  previously `*_input`); `make_degraded_areas()` now takes `iso3`/`pus` (was
+  `country_iso`/`pu`); the built-area threshold is `built_areas_threshold`
+  everywhere (was `built_area_threshold` in `make_restore_zone()` /
+  `make_urban_greening_zone()`); and `make_restore_zone()`'s patch filter is
+  `filter_patch_size` (was `filter_small_patches`). Callers must update named
+  arguments accordingly.
+
+* `make_degraded_areas()` writes its final output as `degraded_areas_{iso3}.tif`
+  (was `restore_zone_{iso3}.tif`, which was easily confused with
+  `make_restore_zone()`'s `restore_zones_{iso3}.tif`).
+
+## New Features
+
+* The zone builders (`make_protect_zone()`, `make_restore_zone()`,
+  `make_manage_zone()`, `make_urban_greening_zone()`) now write their
+  region-aligned intermediate input layers to `output_path` when it is supplied,
+  alongside the final zone raster - matching what `make_degraded_areas()` already
+  did. The files written are, per function:
+  - protect: `agriculture_areas_`, `built_areas_`, `human_pressure_`
+  - restore: `agriculture_areas_`, `built_areas_`, `human_pressure_`,
+    `degradation_`, `forest_mask_`
+  - manage: `agriculture_areas_`, `pasturelands_`, `built_areas_`,
+    `hii_mid60pct_`, `managed_forests_`
+  - urban greening: `built_areas_`
+  Each intermediate is `terra::mask()`-ed to the planning units, so cells outside
+  the study area are NoData (consistent with the zone outputs).
+
+  NOTE: this changes the on-disk output for existing callers that pass
+  `output_path` - they now receive these additional GeoTIFF sidecars. Callers who
+  want only the final zone should point `output_path` at a dedicated directory.
+
+## Bug Fixes
+
+* `make_degraded_areas()` now writes its resampled agriculture and built-area
+  sidecars (`esa_agriculture_resample_`, `built_areas_`) as `FLT4S`. They are
+  bilinear proportions (0-1) and were previously saved as `INT1U`, which
+  truncated them to all-zero.
+
+* `make_restore_zone()` now always saves the `agriculture_areas_` and
+  `built_areas_` intermediates when `output_path` is set, including when they are
+  derived from LULC (previously only saved when passed as explicit rasters).
+
+* `make_normalised_raster()` no longer emits a `warning()` on every
+  `rescaled = FALSE` call (demoted to an informational message), and its internal
+  `output_path` writer uses a valid `INT1S` NoData sentinel (`-128`) instead of
+  the out-of-range `255`.
+
 # elsar 0.3.1
 
 ## Bug Fixes

--- a/R/make_degraded_areas.R
+++ b/R/make_degraded_areas.R
@@ -5,15 +5,15 @@
 #' agriculture, built-up areas, human influence index (HII), and productivity decline layers.
 #' The output is a raster identifying degraded areas according to set thresholds.
 #'
-#' @param country_iso ISO3 country code (e.g., "CHL" for Chile).
-#' @param pu Planning units raster (SpatRaster).
+#' @param iso3 ISO3 country code (e.g., "CHL" for Chile).
+#' @param pus Planning units raster (SpatRaster).
 #' @param sdg_degradation_input Productivity degradation layer (SpatRaster).
-#' @param hii_input Human Influence Index (HII) raster (SpatRaster).
+#' @param human_pressure Human Influence Index (HII) raster (SpatRaster).
 #' @param lulc_proportions A multi-band `SpatRaster` from [download_lulc_proportions()] containing
 #'   pre-computed class proportions. If provided, bands named "agriculture" and "built_area" will
-#'   be used automatically, overriding `agriculture_input` and `built_areas_input`.
-#' @param agriculture_input Agriculture layer (SpatRaster).
-#' @param built_areas_input Built-up areas layer (SpatRaster).
+#'   be used automatically, overriding `agricultural_areas` and `built_areas`.
+#' @param agricultural_areas Agriculture layer (SpatRaster).
+#' @param built_areas Built-up areas layer (SpatRaster).
 #' @param output_path Directory to save output rasters. If NULL, output is not saved.
 #' @param hii_threshold Threshold for the Human Influence Index (default: 4).
 #' @param lulc_threshold Threshold for built and agriculture layers (default: 0.1).
@@ -25,21 +25,21 @@
 #' \dontrun{
 #' restore_zone <- make_degraded_areas(
 #'   "CHL",
-#'   pu,
+#'   pus,
 #'   sdg_degradation_input,
-#'   hii_input,
-#'   agriculture_input,
-#'   built_areas_input,
+#'   human_pressure,
+#'   agricultural_areas,
+#'   built_areas,
 #'   output_path = "./output"
 #'   )
 #' }
-make_degraded_areas <- function(country_iso,
-                                pu,
+make_degraded_areas <- function(iso3,
+                                pus,
                                 sdg_degradation_input = NULL,
-                                hii_input = NULL,
+                                human_pressure = NULL,
                                 lulc_proportions = NULL,
-                                agriculture_input = NULL,
-                                built_areas_input = NULL,
+                                agricultural_areas = NULL,
+                                built_areas = NULL,
                                 output_path = NULL,
                                 hii_threshold = 4,
                                 lulc_threshold = 0.1) {
@@ -49,23 +49,23 @@ make_degraded_areas <- function(country_iso,
   if (!is.null(lulc_proportions)) {
     if (inherits(lulc_proportions, "list")) {
       log_message("Using LULC proportions (list format): {paste(names(lulc_proportions), collapse=', ')}")
-      if ("agriculture" %in% names(lulc_proportions) && is.null(agriculture_input)) {
-        agriculture_input <- lulc_proportions[["agriculture"]]
+      if ("agriculture" %in% names(lulc_proportions) && is.null(agricultural_areas)) {
+        agricultural_areas <- lulc_proportions[["agriculture"]]
         log_message("Using 'agriculture' proportion raster")
       }
-      if ("built_area" %in% names(lulc_proportions) && is.null(built_areas_input)) {
-        built_areas_input <- lulc_proportions[["built_area"]]
+      if ("built_area" %in% names(lulc_proportions) && is.null(built_areas)) {
+        built_areas <- lulc_proportions[["built_area"]]
         log_message("Using 'built_area' proportion raster")
       }
     } else if (inherits(lulc_proportions, "SpatRaster")) {
       band_names <- names(lulc_proportions)
       log_message("Using LULC proportions (SpatRaster): {paste(band_names, collapse=', ')}")
-      if ("agriculture" %in% band_names && is.null(agriculture_input)) {
-        agriculture_input <- lulc_proportions[["agriculture"]]
+      if ("agriculture" %in% band_names && is.null(agricultural_areas)) {
+        agricultural_areas <- lulc_proportions[["agriculture"]]
         log_message("Extracted 'agriculture' band")
       }
-      if ("built_area" %in% band_names && is.null(built_areas_input)) {
-        built_areas_input <- lulc_proportions[["built_area"]]
+      if ("built_area" %in% band_names && is.null(built_areas)) {
+        built_areas <- lulc_proportions[["built_area"]]
         log_message("Extracted 'built_area' band")
       }
     } else {
@@ -74,8 +74,8 @@ make_degraded_areas <- function(country_iso,
   }
 
   # Ensure necessary inputs are provided
-  if (is.null(sdg_degradation_input) || is.null(hii_input) || is.null(agriculture_input) || is.null(built_areas_input)) {
-    stop("All required input rasters (sdg_degradation_input, hii_input, agriculture_input, built_areas_input) must be provided.")
+  if (is.null(sdg_degradation_input) || is.null(human_pressure) || is.null(agricultural_areas) || is.null(built_areas)) {
+    stop("All required input rasters (sdg_degradation_input, human_pressure, agricultural_areas, built_areas) must be provided.")
   }
   if (!is.null(output_path)) {
     assertthat::assert_that(dir.exists(output_path),
@@ -85,65 +85,65 @@ make_degraded_areas <- function(country_iso,
   # Resample and align SDG degradation layer to the planning units (PU) raster
   sdg_degradation_resampled <- terra::resample(
     sdg_degradation_input,
-    terra::project(pu, y = terra::crs(sdg_degradation_input), method = "near"),
+    terra::project(pus, y = terra::crs(sdg_degradation_input), method = "near"),
     method = "near"
   ) %>%
-    terra::project(y = pu, method = "near") %>%
-    terra::resample(y = pu, method = "near") * terra::subst(pu, 0, NA)
+    terra::project(y = pus, method = "near") %>%
+    terra::resample(y = pus, method = "near") * terra::subst(pus, 0, NA)
 
   # Identify degraded areas based on SDG degradation: -1 means degraded, 0 otherwise
   sdg_degraded <- terra::ifel(sdg_degradation_resampled == -1, 1, 0)
 
   # Resample and align agriculture layer
   agriculture_resampled <- terra::resample(
-    agriculture_input,
-    terra::project(pu, y = terra::crs(agriculture_input), method = "near"),
+    agricultural_areas,
+    terra::project(pus, y = terra::crs(agricultural_areas), method = "near"),
     method = "bilinear"
   ) %>%
-    terra::project(y = pu, method = "near") %>%
-    terra::resample(y = pu, method = "bilinear") * terra::subst(pu, 0, NA)
+    terra::project(y = pus, method = "near") %>%
+    terra::resample(y = pus, method = "bilinear") * terra::subst(pus, 0, NA)
 
   # Save the agriculture layer if output_path is provided
   if (!is.null(output_path)) {
     elsar::save_raster(
       raster = agriculture_resampled,
-      filename = glue::glue("{output_path}/esa_agriculture_resample_{country_iso}.tif"),
-      datatype = "INT1U"
+      filename = glue::glue("{output_path}/esa_agriculture_resample_{iso3}.tif"),
+      datatype = "FLT4S"  # bilinear proportion (0-1); INT1U would truncate to 0
     )
   }
 
   # Resample and align built-up areas layer
   built_areas_resampled <- terra::resample(
-    built_areas_input,
-    terra::project(pu, y = terra::crs(built_areas_input), method = "near"),
+    built_areas,
+    terra::project(pus, y = terra::crs(built_areas), method = "near"),
     method = "bilinear"
   ) %>%
-    terra::project(y = pu, method = "near") %>%
-    terra::resample(y = pu, method = "bilinear") * terra::subst(pu, 0, NA)
+    terra::project(y = pus, method = "near") %>%
+    terra::resample(y = pus, method = "bilinear") * terra::subst(pus, 0, NA)
 
   # Save the built-up areas layer if output_path is provided
   if (!is.null(output_path)) {
     elsar::save_raster(
       raster = built_areas_resampled,
-      filename = glue::glue("{output_path}/built_areas_{country_iso}.tif"),
-      datatype = "INT1U"
+      filename = glue::glue("{output_path}/built_areas_{iso3}.tif"),
+      datatype = "FLT4S"  # bilinear proportion (0-1); INT1U would truncate to 0
     )
   }
 
   # Resample and align Human Influence Index (HII) layer
   hii_resampled <- terra::resample(
-    hii_input,
-    terra::project(pu, y = terra::crs(hii_input), method = "near"),
+    human_pressure,
+    terra::project(pus, y = terra::crs(human_pressure), method = "near"),
     method = "near"
   ) %>%
-    terra::project(y = pu, method = "near") %>%
-    terra::resample(y = pu, method = "near") * terra::subst(pu, 0, NA)
+    terra::project(y = pus, method = "near") %>%
+    terra::resample(y = pus, method = "near") * terra::subst(pus, 0, NA)
 
   # Save the HII layer if output_path is provided
   if (!is.null(output_path)) {
     elsar::save_raster(
       raster = hii_resampled,
-      filename = glue::glue("{output_path}/hii_{country_iso}.tif"),
+      filename = glue::glue("{output_path}/hii_{iso3}.tif"),
       datatype = "FLT4S"
     )
   }
@@ -156,18 +156,18 @@ make_degraded_areas <- function(country_iso,
       hii_resampled >= hii_threshold,  # Areas under high human pressure
     1,  # Degraded areas
     0   # Non-degraded areas
-  ) * terra::subst(pu, 0, NA)  # Mask out non-planning unit areas
+  ) * terra::subst(pus, 0, NA)  # Mask out non-planning unit areas
 
   # Save the restoration zone layer if output_path is provided
   if (!is.null(output_path)) {
     elsar::save_raster(
       raster = restore_zone,
-      filename = glue::glue("{output_path}/restore_zone_{country_iso}.tif"),
+      filename = glue::glue("{output_path}/degraded_areas_{iso3}.tif"),
       datatype = "INT1U"
     )
   }
 
-  log_message("Degraded areas/Restore Zone layer created for {country_iso}")
+  log_message("Degraded areas/Restore Zone layer created for {iso3}")
 
   return(restore_zone)  # Return the final restoration zone raster
 }

--- a/R/make_manage_zone.R
+++ b/R/make_manage_zone.R
@@ -14,16 +14,16 @@
 #'
 #' @param iso3 Character. ISO3 country code (e.g., "CHL").
 #' @param pus SpatRaster. Planning units raster to which all inputs are aligned.
-#' @param managed_forests_input SpatRaster. A preprocssed raster of managed forest extent.
+#' @param managed_forests SpatRaster. A preprocssed raster of managed forest extent.
 #' @param raster_mf SpatRaster A raster of forest classes to identify managed forests.
 #' @param lulc_proportions A multi-band `SpatRaster` from [download_lulc_proportions()] containing
 #'   pre-computed class proportions. If provided, bands named "agriculture" and "built_area" will
-#'   be used automatically, overriding `agricultural_areas_input` and `built_areas_input`.
-#' @param agricultural_areas_input SpatRaster. A binary or categorical raster representing agricultural areas.
-#' @param pasturelands_input SpatRaster. A binary or categorical raster representing (actively managed/improved)pastures.
-#' @param built_areas_input SpatRaster. A binary or categorical raster representing built-up/urban areas.
+#'   be used automatically, overriding `agricultural_areas` and `built_areas`.
+#' @param agricultural_areas SpatRaster. A binary or categorical raster representing agricultural areas.
+#' @param pasturelands SpatRaster. A binary or categorical raster representing (actively managed/improved)pastures.
+#' @param built_areas SpatRaster. A binary or categorical raster representing built-up/urban areas.
 #' @param lulc_raster SpatRaster or NULL. Optional raw LULC input used to extract agriculture and built-up layers if those inputs are categorical.
-#' @param hii_input SpatRaster. Human Footprint Index raster.
+#' @param human_pressure SpatRaster. Human Footprint Index raster.
 #' @param pasturelands_threshold Numeric. Probability threshold above which cells are considered pasturelands (default = 0.35).
 #' @param lulc_product Character. LULC product used for class value lookups: "esri_10m" (default),
 #'   "dynamic_world", "esa_worldcover", or "local". When "local", explicit class values must be provided.
@@ -38,7 +38,11 @@
 #' @param built_areas_threshold Numeric. Threshold above which cells are considered built-up and excluded (default = 0.1).
 #' @param filter_patch_size Logical. Whether to remove small patches (default = TRUE).
 #' @param min_patch_size Integer. Minimum size of patches to retain (in cells; default = 10).
-#' @param output_path Character or NULL. If provided, save result to this path as a COG (default = NULL).
+#' @param output_path Character or NULL. When provided, the final zone is saved
+#'   here as a COG (`manage_zone_{iso3}.tif`), together with the region-aligned
+#'   intermediate inputs used to build it - `agriculture_areas_`, `pasturelands_`,
+#'   `built_areas_`, `hii_mid60pct_` and `managed_forests_` `{iso3}.tif` - each
+#'   masked to the planning units (NoData outside the study area). Default NULL.
 #'
 #' @return A SpatRaster with two layers: `manage_zone_v1` and `manage_zone_v2`.
 #'
@@ -51,12 +55,12 @@
 #' manage_zone <- make_manage_zone(
 #'   iso3 = "CHL",
 #'   pus = planning_units,
-#'   managed_forests_input = forest_raster,
-#'   agricultural_areas_input = agri_raster,
-#'   pasturelands_input = pastures_raster,
-#'   built_areas_input = built_raster,
+#'   managed_forests = forest_raster,
+#'   agricultural_areas = agri_raster,
+#'   pasturelands = pastures_raster,
+#'   built_areas = built_raster,
 #'   lulc_raster = landcover_raster,
-#'   hii_input = hfp_raster,
+#'   human_pressure = hfp_raster,
 #'   output_path = "outputs/"
 #' )
 #' }
@@ -64,14 +68,14 @@
 make_manage_zone <- function(
     iso3,
     pus,
-    managed_forests_input,
+    managed_forests,
     raster_mf = NULL,
     lulc_proportions = NULL,
-    agricultural_areas_input = NULL,
-    pasturelands_input = NULL,
-    built_areas_input = NULL,
+    agricultural_areas = NULL,
+    pasturelands = NULL,
+    built_areas = NULL,
     lulc_raster = NULL,
-    hii_input = NULL,
+    human_pressure = NULL,
     pasturelands_threshold = 0.35,
     lulc_product = c("esri_10m", "dynamic_world", "esa_worldcover", "local"),
     agriculture_lulc_value = NULL,
@@ -91,23 +95,23 @@ make_manage_zone <- function(
   if (!is.null(lulc_proportions)) {
     if (inherits(lulc_proportions, "list")) {
       log_message("Using LULC proportions (list format): {paste(names(lulc_proportions), collapse=', ')}")
-      if ("agriculture" %in% names(lulc_proportions) && is.null(agricultural_areas_input)) {
-        agricultural_areas_input <- lulc_proportions[["agriculture"]]
+      if ("agriculture" %in% names(lulc_proportions) && is.null(agricultural_areas)) {
+        agricultural_areas <- lulc_proportions[["agriculture"]]
         log_message("Using 'agriculture' proportion raster")
       }
-      if ("built_area" %in% names(lulc_proportions) && is.null(built_areas_input)) {
-        built_areas_input <- lulc_proportions[["built_area"]]
+      if ("built_area" %in% names(lulc_proportions) && is.null(built_areas)) {
+        built_areas <- lulc_proportions[["built_area"]]
         log_message("Using 'built_area' proportion raster")
       }
     } else if (inherits(lulc_proportions, "SpatRaster")) {
       band_names <- names(lulc_proportions)
       log_message("Using LULC proportions (SpatRaster): {paste(band_names, collapse=', ')}")
-      if ("agriculture" %in% band_names && is.null(agricultural_areas_input)) {
-        agricultural_areas_input <- lulc_proportions[["agriculture"]]
+      if ("agriculture" %in% band_names && is.null(agricultural_areas)) {
+        agricultural_areas <- lulc_proportions[["agriculture"]]
         log_message("Extracted 'agriculture' band")
       }
-      if ("built_area" %in% band_names && is.null(built_areas_input)) {
-        built_areas_input <- lulc_proportions[["built_area"]]
+      if ("built_area" %in% band_names && is.null(built_areas)) {
+        built_areas <- lulc_proportions[["built_area"]]
         log_message("Extracted 'built_area' band")
       }
     } else {
@@ -117,7 +121,7 @@ make_manage_zone <- function(
 
   # Resolve LULC class values from product if not explicitly provided
   # (only needed if using lulc_raster fallback)
-  if (is.null(agricultural_areas_input) || is.null(built_areas_input)) {
+  if (is.null(agricultural_areas) || is.null(built_areas)) {
     if (is.null(agriculture_lulc_value)) {
       if (lulc_product == "local") {
         stop("When lulc_product = 'local', agriculture_lulc_value must be explicitly provided.", call. = FALSE)
@@ -150,23 +154,23 @@ make_manage_zone <- function(
 
   # Ensure agricultural/built data is supplied or can be derived
   assertthat::assert_that(
-    !(is.null(agricultural_areas_input) && is.null(built_areas_input) && is.null(lulc_raster)),
-    msg = "Either 'agricultural_areas_input' and/or 'built_areas_input' must be provided, or 'lulc_raster' must be supplied to derive them."
+    !(is.null(agricultural_areas) && is.null(built_areas) && is.null(lulc_raster)),
+    msg = "Either 'agricultural_areas' and/or 'built_areas' must be provided, or 'lulc_raster' must be supplied to derive them."
   )
 
   # Check required raster inputs
-  assertthat::assert_that(inherits(hii_input, "SpatRaster"), msg = "'hii_input' must be a SpatRaster.")
-  assertthat::assert_that(inherits(managed_forests_input, "SpatRaster"), msg = "'managed_forests_input' must be a SpatRaster.")
+  assertthat::assert_that(inherits(human_pressure, "SpatRaster"), msg = "'human_pressure' must be a SpatRaster.")
+  assertthat::assert_that(inherits(managed_forests, "SpatRaster"), msg = "'managed_forests' must be a SpatRaster.")
 
   # If provided, validate optional rasters
-  if (!is.null(agricultural_areas_input)) {
-    assertthat::assert_that(inherits(agricultural_areas_input, "SpatRaster"), msg = "'agricultural_areas_input' must be a SpatRaster.")
+  if (!is.null(agricultural_areas)) {
+    assertthat::assert_that(inherits(agricultural_areas, "SpatRaster"), msg = "'agricultural_areas' must be a SpatRaster.")
   }
-  if (!is.null(pasturelands_input)) {
-    assertthat::assert_that(inherits(pasturelands_input, "SpatRaster"), msg = "'pasturelands_input' must be a SpatRaster.")
+  if (!is.null(pasturelands)) {
+    assertthat::assert_that(inherits(pasturelands, "SpatRaster"), msg = "'pasturelands' must be a SpatRaster.")
   }
-  if (!is.null(built_areas_input)) {
-    assertthat::assert_that(inherits(built_areas_input, "SpatRaster"), msg = "'built_areas_input' must be a SpatRaster.")
+  if (!is.null(built_areas)) {
+    assertthat::assert_that(inherits(built_areas, "SpatRaster"), msg = "'built_areas' must be a SpatRaster.")
   }
   if (!is.null(lulc_raster)) {
     assertthat::assert_that(inherits(lulc_raster, "SpatRaster"), msg = "'lulc_raster' must be a SpatRaster.")
@@ -178,17 +182,17 @@ make_manage_zone <- function(
 
   # Process agricultural areas
   log_message("Processing agricultural areas...")
-  if (!is.null(agricultural_areas_input)) {
+  if (!is.null(agricultural_areas)) {
     log_message("Aligning provided agricultural areas raster to planning units...")
-    agricultural_areas <- elsar::make_normalised_raster(
-      raster_in = agricultural_areas_input,
+    agricultural_areas_processed <- elsar::make_normalised_raster(
+      raster_in = agricultural_areas,
       pus = pus,
       iso3 = iso3,
       rescaled = FALSE,
       method_override = "mean"
     )
   } else {
-    agricultural_areas <- elsar::make_normalised_raster(
+    agricultural_areas_processed <- elsar::make_normalised_raster(
       raster_in = lulc_raster,
       pus = pus,
       iso3 = iso3,
@@ -200,8 +204,8 @@ make_manage_zone <- function(
 
   # Process pasturelands
   log_message("Processing pasturelands...")
-  pasturelands <- elsar::make_normalised_raster(
-    raster_in = pasturelands_input,
+  pasturelands_processed <- elsar::make_normalised_raster(
+    raster_in = pasturelands,
     pus = pus,
     iso3 = iso3,
     method_override = "mean"
@@ -209,17 +213,17 @@ make_manage_zone <- function(
 
   # Process built-up areas
   log_message("Processing built-up areas...")
-  if (!is.null(built_areas_input)) {
+  if (!is.null(built_areas)) {
     log_message("Aligning provided built areas raster to planning units...")
-    built_areas <- elsar::make_normalised_raster(
-      raster_in = built_areas_input,
+    built_areas_processed <- elsar::make_normalised_raster(
+      raster_in = built_areas,
       pus = pus,
       iso3 = iso3,
       rescaled = FALSE,
       method_override = "mean"
     )
   } else {
-    built_areas <- elsar::make_normalised_raster(
+    built_areas_processed <- elsar::make_normalised_raster(
       raster_in = lulc_raster,
       pus = pus,
       iso3 = iso3,
@@ -232,7 +236,7 @@ make_manage_zone <- function(
   # Normalize HFP and extract middle 60%
   log_message("Processing HII layer and extracting middle 60% quantile range...")
   hii_resampled <- elsar::make_normalised_raster(
-    raster_in = hii_input,
+    raster_in = human_pressure,
     pus = pus,
     iso3 = iso3,
     rescaled = FALSE,
@@ -246,10 +250,10 @@ make_manage_zone <- function(
 
   # Process managed forests
   log_message("Processing managed forests...")
-  if (!is.null(managed_forests_input)) {
+  if (!is.null(managed_forests)) {
     log_message("Aligning provided managed forests raster to planning units...")
-    managed_forests <- elsar::make_normalised_raster(
-      raster_in = managed_forests_input,
+    managed_forests_processed <- elsar::make_normalised_raster(
+      raster_in = managed_forests,
       pus = pus,
       iso3 = iso3,
       rescaled = FALSE,
@@ -257,22 +261,22 @@ make_manage_zone <- function(
     )
   } else {
   # Normalise and reclass
-    managed_forests <- elsar::make_managed_forests(
+    managed_forests_processed <- elsar::make_managed_forests(
       raster_in = raster_mf,
       pus = pus,
       iso3 = iso3,
       make_productive = FALSE)
 
-  managed_forests <- managed_forests[[1]]
+  managed_forests_processed <- managed_forests_processed[[1]]
   }
 
   # Main management zone: moderate HFP, OR managed forests, OR ag areas — minus built-up
   log_message("Creating the default manage zone using middle 60% of HII value, managed forests, agricultural areas, and pasturelands...")
   manage_zone <- terra::ifel(
     hii_middle_60_pct == 1 |
-      managed_forests > forest_class_threshold |
-      agricultural_areas > agriculture_threshold |
-      pasturelands > pasturelands_threshold,
+      managed_forests_processed > forest_class_threshold |
+      agricultural_areas_processed > agriculture_threshold |
+      pasturelands_processed > pasturelands_threshold,
     1, 0
   ) %>% make_normalised_raster(
     pus = pus,
@@ -280,14 +284,14 @@ make_manage_zone <- function(
 
   # Exclude built-up areas
   log_message("Excluding built areas from the manage zone...")
-  manage_zone <- terra::ifel(built_areas > built_areas_threshold, 0, manage_zone) %>%
+  manage_zone <- terra::ifel(built_areas_processed > built_areas_threshold, 0, manage_zone) %>%
     make_normalised_raster(pus = pus, iso3 = iso3)
 
   # Secondary zone (agriculture and pastureland only)
   log_message("Creating the alternative manage zone using agricultural areas and pasturelands only...")
   manage_zone_alt <- terra::ifel(
-    agricultural_areas > agriculture_threshold |
-      pasturelands > pasturelands_threshold,
+    agricultural_areas_processed > agriculture_threshold |
+      pasturelands_processed > pasturelands_threshold,
     1, 0
     ) %>%
     make_normalised_raster(pus = pus, iso3 = iso3)
@@ -312,6 +316,26 @@ make_manage_zone <- function(
       filename = filename,
       datatype = "INT1U"
     )
+
+    # Also save the region-aligned intermediate inputs for inspection (mirrors
+    # make_degraded_areas). Each is guarded because some inputs are optional, and
+    # masked to the planning units so cells outside the study area are NoData.
+    pu_mask <- function(r) terra::mask(r, pus)
+    if (exists("agricultural_areas_processed", inherits = FALSE) && inherits(agricultural_areas_processed, "SpatRaster")) {
+      elsar::save_raster(pu_mask(agricultural_areas_processed), glue::glue("{output_path}/agriculture_areas_{iso3}.tif"), datatype = "FLT4S")
+    }
+    if (exists("pasturelands_processed", inherits = FALSE) && inherits(pasturelands_processed, "SpatRaster")) {
+      elsar::save_raster(pu_mask(pasturelands_processed), glue::glue("{output_path}/pasturelands_{iso3}.tif"), datatype = "FLT4S")
+    }
+    if (exists("built_areas_processed", inherits = FALSE) && inherits(built_areas_processed, "SpatRaster")) {
+      elsar::save_raster(pu_mask(built_areas_processed), glue::glue("{output_path}/built_areas_{iso3}.tif"), datatype = "FLT4S")
+    }
+    if (exists("hii_middle_60_pct", inherits = FALSE) && inherits(hii_middle_60_pct, "SpatRaster")) {
+      elsar::save_raster(pu_mask(hii_middle_60_pct), glue::glue("{output_path}/hii_mid60pct_{iso3}.tif"), datatype = "INT1U")
+    }
+    if (exists("managed_forests_processed", inherits = FALSE) && inherits(managed_forests_processed, "SpatRaster")) {
+      elsar::save_raster(pu_mask(managed_forests_processed), glue::glue("{output_path}/managed_forests_{iso3}.tif"), datatype = "FLT4S")
+    }
   }
 
   return(manage_zones)

--- a/R/make_normalised_raster.R
+++ b/R/make_normalised_raster.R
@@ -18,8 +18,11 @@
 #'        function to the raster before resampling to the PU layer (default: `NULL`).
 #' @param conditional_expression `function` Optional method to apply a function to the
 #'        raster after resampling to the PU layer (default: `NULL`).
-#' @param fill_na `numeric` or `NA` The fill value to use to fill in `NA` values before
-#'        masking (default: 0).
+#' @param fill_na `numeric` or `NA` The fill value used for `NA` cells before
+#'        masking (default: 0). When non-NULL (the default), filled cells are
+#'        then masked back to the planning units, so the result is NoData outside
+#'        the study area. Pass `NULL` to skip both the fill and this PU masking -
+#'        in which case cells outside the planning units are NOT set to NoData.
 #' @param name_out `character` The name of the output raster file (without the extension).
 #' @param output_path `character` The directory path to save the output raster (default: `NULL`, i.e., not saved).
 #' @param threads Optional method to use multi-core processing - to speed on some `terra`
@@ -232,12 +235,16 @@ make_normalised_raster <- function(raster_in,
   if (rescaled) {
     dat_aligned <- elsar::rescale_raster(dat_aligned)
   } else {
-    warning("NOTE: Raster values are NOT rescaled.")
+    # A deliberate, common choice for presence/coverage layers - inform, don't
+    # warn (warning() here fires dozens of times per pipeline run).
+    log_message("Raster values are NOT rescaled (rescaled = FALSE).")
   }
 
   if (!is.null(output_path)) {
     data_type <- if (terra::is.int(dat_aligned)) "INT1S" else "FLT4S"
-    na_value <- if (terra::is.int(dat_aligned)) 255 else -9999
+    # INT1S is signed (-128..127); 255 is out of range. Use -128 as the NoData
+    # sentinel for integer output (the `invert` path can produce negatives).
+    na_value <- if (terra::is.int(dat_aligned)) -128 else -9999
 
     gdal_options <- c(
       "COMPRESS=ZSTD",

--- a/R/make_protect_zone.R
+++ b/R/make_protect_zone.R
@@ -14,11 +14,11 @@
 #'        If NULL, `elsar::make_protected_areas()` will be used.
 #' @param lulc_proportions A multi-band `SpatRaster` from [download_lulc_proportions()] containing
 #'   pre-computed class proportions. If provided, bands named "agriculture" and "built_area" will
-#'   be used automatically, overriding `agricultural_areas_input` and `built_areas_input`.
-#' @param agricultural_areas_input A `SpatRaster` representing binary or probabilistic agricultural areas (optional).
-#' @param built_areas_input A `SpatRaster` representing binary or probabilistic built-up areas (optional).
+#'   be used automatically, overriding `agricultural_areas` and `built_areas`.
+#' @param agricultural_areas A `SpatRaster` representing binary or probabilistic agricultural areas (optional).
+#' @param built_areas A `SpatRaster` representing binary or probabilistic built-up areas (optional).
 #' @param lulc_raster A `SpatRaster` LULC map used to extract agriculture/built-up areas if not already provided (default: NULL).
-#' @param hii_input A `SpatRaster` of the Human Footprint Index, or NULL. If NULL,
+#' @param human_pressure A `SpatRaster` of the Human Footprint Index, or NULL. If NULL,
 #'   the protect zone starts with all planning units eligible and applies only
 #'   agriculture and built-area exclusions.
 #' @param hii_threshold A fixed numeric HII threshold. If NULL, `hii_quantile` is used to estimate it.
@@ -34,7 +34,11 @@
 #' @param filter_patch_size Logical. Whether to remove small isolated patches (default: TRUE).
 #' @param min_patch_size Integer. Minimum patch size to retain (in raster cells; default: 20).
 #' @param make_locked_out Logical. If TRUE, invert the raster to produce a locked-out constraint (default: FALSE).
-#' @param output_path Optional directory to write the result as a COG.
+#' @param output_path Optional directory. When provided, the final zone is
+#'   written there as a COG (`protect_zone_{iso3}.tif`), together with the
+#'   region-aligned intermediate inputs used to build it - `agriculture_areas_`,
+#'   `built_areas_` and `human_pressure_` `{iso3}.tif` - each masked to the
+#'   planning units (NoData outside the study area).
 #'
 #' @return A `SpatRaster` with values 1 (eligible) and 0 (excluded), or the inverse if `make_locked_out = TRUE`.
 #' @export
@@ -44,9 +48,9 @@
 #' protect_zone <- make_protect_zone(
 #'   pus = planning_units,
 #'   iso3 = "NPL",
-#'   hii_input = hii_raster,
-#'   agricultural_areas_input = crop_raster,
-#'   built_areas_input = built_raster,
+#'   human_pressure = hii_raster,
+#'   agricultural_areas = crop_raster,
+#'   built_areas = built_raster,
 #'   lulc_raster = NULL,
 #'   hii_quantile = 0.95,
 #'   output_path = "outputs/"
@@ -58,10 +62,10 @@ make_protect_zone <- function(
     pus,
     current_protected_areas,
     lulc_proportions = NULL,
-    agricultural_areas_input = NULL,
-    built_areas_input = NULL,
+    agricultural_areas = NULL,
+    built_areas = NULL,
     lulc_raster = NULL,
-    hii_input = NULL,
+    human_pressure = NULL,
     hii_threshold = NULL,
     hii_quantile = 0.95,
     lulc_product = c("esri_10m", "dynamic_world", "esa_worldcover", "local"),
@@ -82,24 +86,24 @@ make_protect_zone <- function(
     if (inherits(lulc_proportions, "list")) {
       # New format: named list of SpatRasters
       log_message("Using LULC proportions (list format): {paste(names(lulc_proportions), collapse=', ')}")
-      if ("agriculture" %in% names(lulc_proportions) && is.null(agricultural_areas_input)) {
-        agricultural_areas_input <- lulc_proportions[["agriculture"]]
+      if ("agriculture" %in% names(lulc_proportions) && is.null(agricultural_areas)) {
+        agricultural_areas <- lulc_proportions[["agriculture"]]
         log_message("Using 'agriculture' proportion raster")
       }
-      if ("built_area" %in% names(lulc_proportions) && is.null(built_areas_input)) {
-        built_areas_input <- lulc_proportions[["built_area"]]
+      if ("built_area" %in% names(lulc_proportions) && is.null(built_areas)) {
+        built_areas <- lulc_proportions[["built_area"]]
         log_message("Using 'built_area' proportion raster")
       }
     } else if (inherits(lulc_proportions, "SpatRaster")) {
       # Legacy format: multi-band SpatRaster
       band_names <- names(lulc_proportions)
       log_message("Using LULC proportions (SpatRaster): {paste(band_names, collapse=', ')}")
-      if ("agriculture" %in% band_names && is.null(agricultural_areas_input)) {
-        agricultural_areas_input <- lulc_proportions[["agriculture"]]
+      if ("agriculture" %in% band_names && is.null(agricultural_areas)) {
+        agricultural_areas <- lulc_proportions[["agriculture"]]
         log_message("Extracted 'agriculture' band")
       }
-      if ("built_area" %in% band_names && is.null(built_areas_input)) {
-        built_areas_input <- lulc_proportions[["built_area"]]
+      if ("built_area" %in% band_names && is.null(built_areas)) {
+        built_areas <- lulc_proportions[["built_area"]]
         log_message("Extracted 'built_area' band")
       }
     } else {
@@ -109,7 +113,7 @@ make_protect_zone <- function(
 
   # Resolve LULC class values from product if not explicitly provided
   # (only needed if using lulc_raster fallback)
-  if (is.null(agricultural_areas_input) || is.null(built_areas_input)) {
+  if (is.null(agricultural_areas) || is.null(built_areas)) {
     if (is.null(agriculture_lulc_value)) {
       if (lulc_product == "local") {
         stop("When lulc_product = 'local', agriculture_lulc_value must be explicitly provided.", call. = FALSE)
@@ -145,19 +149,19 @@ make_protect_zone <- function(
 
   # Process agriculture
   log_message("Processing agricultural areas...")
-  if (!is.null(agricultural_areas_input)) {
+  if (!is.null(agricultural_areas)) {
     log_message("Aligning provided agricultural areas raster to planning units...")
-    agricultural_areas <- elsar::make_normalised_raster(
-      raster_in = agricultural_areas_input,
+    agricultural_areas_processed <- elsar::make_normalised_raster(
+      raster_in = agricultural_areas,
       pus = pus,
       iso3 = iso3,
       rescaled = FALSE,
       method_override = "mean"
     )
   } else {
-    assertthat::assert_that(!is.null(lulc_raster), msg = "If 'agricultural_areas_input' is NULL, 'lulc_raster' must be provided.")
+    assertthat::assert_that(!is.null(lulc_raster), msg = "If 'agricultural_areas' is NULL, 'lulc_raster' must be provided.")
     log_message("Extracting agricultural areas from LULC raster...")
-    agricultural_areas <- elsar::make_normalised_raster(
+    agricultural_areas_processed <- elsar::make_normalised_raster(
       raster_in = lulc_raster,
       pus = pus,
       iso3 = iso3,
@@ -169,19 +173,19 @@ make_protect_zone <- function(
 
   # Process built-up areas
   log_message("Processing built-up areas...")
-  if (!is.null(built_areas_input)) {
+  if (!is.null(built_areas)) {
     log_message("Aligning provided built areas raster to planning units...")
-    built_areas <- elsar::make_normalised_raster(
-      raster_in = built_areas_input,
+    built_areas_processed <- elsar::make_normalised_raster(
+      raster_in = built_areas,
       pus = pus,
       iso3 = iso3,
       rescaled = FALSE,
       method_override = "mean"
     )
   } else {
-    assertthat::assert_that(!is.null(lulc_raster), msg = "If 'built_areas_input' is NULL, 'lulc_raster' must be provided.")
+    assertthat::assert_that(!is.null(lulc_raster), msg = "If 'built_areas' is NULL, 'lulc_raster' must be provided.")
     log_message("Extracting built areas from LULC raster...")
-    built_areas <-  elsar::make_normalised_raster(
+    built_areas_processed <-  elsar::make_normalised_raster(
       raster_in = lulc_raster,
       pus = pus,
       iso3 = iso3,
@@ -193,11 +197,11 @@ make_protect_zone <- function(
 
   # Create base protect zone from HII or start with all eligible
 
-  if (!is.null(hii_input)) {
+  if (!is.null(human_pressure)) {
     # Normalize HII
     log_message("Processing HII raster...")
     hii_resampled <- elsar::make_normalised_raster(
-      raster_in = hii_input,
+      raster_in = human_pressure,
       pus = pus,
       iso3 = iso3,
       rescaled = FALSE,
@@ -241,12 +245,12 @@ make_protect_zone <- function(
 
   # Exclude agriculture and built-up areas
   log_message("Removing built and agricultural areas...")
-  if (!is.null(built_areas) && is.null(agricultural_areas)) {
-    protect_zone <- terra::ifel(built_areas > built_areas_threshold, 0, protect_zone)
-  } else if (is.null(built_areas) && !is.null(agricultural_areas)) {
-    protect_zone <- terra::ifel(agricultural_areas > agriculture_threshold, 0, protect_zone)
-  } else if (!is.null(built_areas) && !is.null(agricultural_areas)) {
-    protect_zone <- terra::ifel(built_areas > built_areas_threshold | agricultural_areas > agriculture_threshold, 0, protect_zone)
+  if (!is.null(built_areas_processed) && is.null(agricultural_areas_processed)) {
+    protect_zone <- terra::ifel(built_areas_processed > built_areas_threshold, 0, protect_zone)
+  } else if (is.null(built_areas_processed) && !is.null(agricultural_areas_processed)) {
+    protect_zone <- terra::ifel(agricultural_areas_processed > agriculture_threshold, 0, protect_zone)
+  } else if (!is.null(built_areas_processed) && !is.null(agricultural_areas_processed)) {
+    protect_zone <- terra::ifel(built_areas_processed > built_areas_threshold | agricultural_areas_processed > agriculture_threshold, 0, protect_zone)
   } else {
     log_message("No building or agricultural area found - Protection zone based on HII only.")
   }
@@ -273,6 +277,20 @@ make_protect_zone <- function(
       filename = filename,
       datatype = "INT1U"
     )
+
+    # Also save the region-aligned intermediate inputs for inspection (mirrors
+    # make_degraded_areas). Each is guarded because some inputs are optional, and
+    # masked to the planning units so cells outside the study area are NoData.
+    pu_mask <- function(r) terra::mask(r, pus)
+    if (exists("agricultural_areas_processed", inherits = FALSE) && inherits(agricultural_areas_processed, "SpatRaster")) {
+      elsar::save_raster(pu_mask(agricultural_areas_processed), glue::glue("{output_path}/agriculture_areas_{iso3}.tif"), datatype = "FLT4S")
+    }
+    if (exists("built_areas_processed", inherits = FALSE) && inherits(built_areas_processed, "SpatRaster")) {
+      elsar::save_raster(pu_mask(built_areas_processed), glue::glue("{output_path}/built_areas_{iso3}.tif"), datatype = "FLT4S")
+    }
+    if (exists("hii_resampled", inherits = FALSE) && inherits(hii_resampled, "SpatRaster")) {
+      elsar::save_raster(pu_mask(hii_resampled), glue::glue("{output_path}/human_pressure_{iso3}.tif"), datatype = "FLT4S")
+    }
   }
 
   return(protect_zone)

--- a/R/make_restore_zone.R
+++ b/R/make_restore_zone.R
@@ -37,7 +37,7 @@
 #'   an area is considered degraded (default: 4).
 #' @param agriculture_threshold Numeric. Proportion threshold above which an area
 #'   is excluded as agricultural land (default: 0.1).
-#' @param built_area_threshold Numeric. Proportion threshold above which an area
+#' @param built_areas_threshold Numeric. Proportion threshold above which an area
 #'   is excluded as built-up land (default: 0.1).
 #' @param forest_threshold Numeric. Minimum forest cover proportion to include
 #'   in restore_zone_v2 (default: 0.1).
@@ -47,12 +47,16 @@
 #'   agricultural land (default: 5, for ESRI 10m LULC).
 #' @param built_area_lulc_value Integer. Class value in `lulc` representing built-up
 #'   areas (default: 7, for ESRI 10m LULC).
-#' @param filter_small_patches Logical. Whether to remove small isolated patches
+#' @param filter_patch_size Logical. Whether to remove small isolated patches
 #'   from the output (default: TRUE).
 #' @param min_patch_size Integer. Minimum number of connected pixels to retain
 #'   when filtering patches (default: 10).
-#' @param output_path Character or NULL. Directory to save output rasters as
-#'   Cloud Optimized GeoTIFFs. If NULL, outputs are returned but not saved.
+#' @param output_path Character or NULL. When provided, the final zones are saved
+#'   here as a Cloud Optimized GeoTIFF (`restore_zones_{iso3}.tif`), together with
+#'   the region-aligned intermediate inputs used to build them - `agriculture_areas_`,
+#'   `built_areas_`, `human_pressure_`, `degradation_` and `forest_mask_`
+#'   `{iso3}.tif` - each masked to the planning units (NoData outside the study
+#'   area). If NULL, outputs are returned but not saved.
 #'
 #' @return A SpatRaster with two layers:
 #' \describe{
@@ -91,11 +95,11 @@
 #' restore_zone <- make_restore_zone(
 #'   iso3 = "BRA",
 #'   pus = planning_units,
-#'   sdg_degradation_input = sdg_raster,
-#'   agricultural_areas_input = ag_raster,
-#'   built_areas_input = built_raster,
-#'   hii_input = hii_raster,
-#'   forest_cover_input = forest_raster
+#'   degradation = sdg_raster,
+#'   agricultural_areas = ag_raster,
+#'   built_areas = built_raster,
+#'   human_pressure = hii_raster,
+#'   forest_mask = forest_raster
 #' )
 #' }
 
@@ -112,12 +116,12 @@ make_restore_zone <- function(
     degradation_threshold = 0.1,
     human_pressure_threshold = 4,
     agriculture_threshold = 0.1,
-    built_area_threshold = 0.1,
+    built_areas_threshold = 0.1,
     forest_threshold = 0.1,
     lulc_product = c("esri_10m", "dynamic_world", "esa_worldcover", "local"),
     agriculture_lulc_value = NULL,
     built_area_lulc_value = NULL,
-    filter_small_patches = TRUE,
+    filter_patch_size = TRUE,
     min_patch_size = 10,
     output_path = NULL
 ) {
@@ -266,15 +270,18 @@ make_restore_zone <- function(
     method_override = "mean"
   )
 
-  # Optional output of intermediate layers
+  # Optional output of intermediate layers. Masked to the planning units so cells
+  # outside the study area are NoData (consistent with the zone outputs).
   if (!is.null(output_path)) {
-    if (!is.null(agricultural_areas)) {
-      save_raster(agricultural_areas_processed, glue::glue("{output_path}/agriculture_areas_{iso3}.tif"))
-    }
-    if (!is.null(built_areas)) {
-      save_raster(built_areas_processed, glue::glue("{output_path}/built_areas_{iso3}.tif"))
-    }
-    save_raster(human_pressure_processed, glue::glue("{output_path}/human_pressure_{iso3}.tif"))
+    pu_mask <- function(r) terra::mask(r, pus)
+    # agricultural_areas_processed / built_areas_processed are always computed
+    # (from the direct input or derived from LULC), so save them unconditionally -
+    # the LULC-derived proportion is often the most useful to inspect.
+    save_raster(pu_mask(agricultural_areas_processed), glue::glue("{output_path}/agriculture_areas_{iso3}.tif"))
+    save_raster(pu_mask(built_areas_processed), glue::glue("{output_path}/built_areas_{iso3}.tif"))
+    save_raster(pu_mask(human_pressure_processed), glue::glue("{output_path}/human_pressure_{iso3}.tif"))
+    save_raster(pu_mask(degradation_processed), glue::glue("{output_path}/degradation_{iso3}.tif"))
+    save_raster(pu_mask(forest_mask_processed), glue::glue("{output_path}/forest_mask_{iso3}.tif"))
   }
 
   # Combine degradation indicators into restore zone v1 (the Default Restore Zone)
@@ -282,7 +289,7 @@ make_restore_zone <- function(
   restore_zone <- terra::ifel(
     (degradation_processed > degradation_threshold | human_pressure_processed >= human_pressure_threshold) &
       agricultural_areas_processed <= agriculture_threshold &
-      built_areas_processed <= built_area_threshold,
+      built_areas_processed <= built_areas_threshold,
     1, 0
   ) %>%
     elsar::make_normalised_raster(
@@ -306,7 +313,7 @@ make_restore_zone <- function(
   names(restore_zones) <- c("restore_zone_v1", "restore_zone_v2")
 
   # Optionally remove small patches (default behaviour)
-  if (filter_small_patches) {
+  if (filter_patch_size) {
     restore_zones[[1]] <- terra::sieve(restore_zones[[1]], threshold = min_patch_size)
 
     if (terra::nlyr(restore_zones) > 1) {

--- a/R/make_urban_greening_zone.R
+++ b/R/make_urban_greening_zone.R
@@ -11,24 +11,27 @@
 #'
 #' @param iso3 ISO3 country code (e.g., "NPL").
 #' @param pus A `SpatRaster` defining the planning units.
-#' @param built_areas_input A `SpatRaster` representing binary or probabilistic built-up areas (optional).
+#' @param built_areas A `SpatRaster` representing binary or probabilistic built-up areas (optional).
 #'   If provided, this takes priority over extraction from other inputs.
 #' @param lulc_proportions A multi-band `SpatRaster` or list from [download_lulc_proportions()] containing
 #'   pre-computed class proportions. If provided and contains "built_area", will be used
-#'   if `built_areas_input` is NULL.
+#'   if `built_areas` is NULL.
 #' @param lulc_raster A `SpatRaster` LULC map used to extract built-up areas if not already provided (default: NULL).
 #' @param lulc_product Character. LULC product used for class value lookups: "esri_10m" (default),
 #'   "dynamic_world", "esa_worldcover", or "local". When "local", `built_area_lulc_value` must be provided.
 #' @param built_area_lulc_value Integer or NULL. LULC value representing built-up areas. If NULL,
 #'   automatically determined from `lulc_product`. Default is NULL.
-#' @param built_area_threshold Minimum fraction for built-up area to be included (default: 0).
+#' @param built_areas_threshold Minimum fraction for built-up area to be included (default: 0).
 #'   A threshold of 0 includes all urban areas, which is recommended since urban areas
 #'   are often small and should be preserved.
 #' @param filter_patch_size Logical. Whether to remove small isolated patches (default: FALSE).
 #'   Defaults to FALSE because urban areas are often small and should be preserved.
 #' @param min_patch_size Integer. Minimum patch size to retain (in raster cells; default: 10).
 #'   Only used if `filter_patch_size = TRUE`.
-#' @param output_path Optional directory to write the result as a COG.
+#' @param output_path Optional directory. When provided, the final zone is
+#'   written there as a COG (`urban_greening_zone_{iso3}.tif`), together with the
+#'   region-aligned `built_areas_{iso3}.tif` input used to build it, masked to the
+#'   planning units (NoData outside the study area).
 #'
 #' @return A `SpatRaster` with values 1 (urban greening zone) and 0 (not urban).
 #' @export
@@ -38,7 +41,7 @@
 #' urban_greening_zone <- make_urban_greening_zone(
 #'   pus = planning_units,
 #'   iso3 = "NPL",
-#'   built_areas_input = built_raster,
+#'   built_areas = built_raster,
 #'   output_path = "outputs/"
 #' )
 #' }
@@ -46,12 +49,12 @@
 make_urban_greening_zone <- function(
     iso3,
     pus,
-    built_areas_input = NULL,
+    built_areas = NULL,
     lulc_proportions = NULL,
     lulc_raster = NULL,
     lulc_product = c("esri_10m", "dynamic_world", "esa_worldcover", "local"),
     built_area_lulc_value = NULL,
-    built_area_threshold = 0,
+    built_areas_threshold = 0,
     filter_patch_size = FALSE,
     min_patch_size = 10,
     output_path = NULL
@@ -60,12 +63,12 @@ make_urban_greening_zone <- function(
 
   # If lulc_proportions provided, extract built_area
   # Supports both list format (new) and SpatRaster format (legacy)
-  if (!is.null(lulc_proportions) && is.null(built_areas_input)) {
+  if (!is.null(lulc_proportions) && is.null(built_areas)) {
     if (inherits(lulc_proportions, "list")) {
       # New format: named list of SpatRasters
       log_message("Using LULC proportions (list format): {paste(names(lulc_proportions), collapse=', ')}")
       if ("built_area" %in% names(lulc_proportions)) {
-        built_areas_input <- lulc_proportions[["built_area"]]
+        built_areas <- lulc_proportions[["built_area"]]
         log_message("Using 'built_area' proportion raster")
       }
     } else if (inherits(lulc_proportions, "SpatRaster")) {
@@ -73,7 +76,7 @@ make_urban_greening_zone <- function(
       band_names <- names(lulc_proportions)
       log_message("Using LULC proportions (SpatRaster): {paste(band_names, collapse=', ')}")
       if ("built_area" %in% band_names) {
-        built_areas_input <- lulc_proportions[["built_area"]]
+        built_areas <- lulc_proportions[["built_area"]]
         log_message("Extracted 'built_area' band")
       }
     } else {
@@ -83,7 +86,7 @@ make_urban_greening_zone <- function(
 
   # Resolve LULC class value from product if not explicitly provided
   # (only needed if using lulc_raster fallback)
-  if (is.null(built_areas_input) && is.null(built_area_lulc_value)) {
+  if (is.null(built_areas) && is.null(built_area_lulc_value)) {
     if (lulc_product == "local") {
       stop("When lulc_product = 'local', built_area_lulc_value must be explicitly provided.", call. = FALSE)
     }
@@ -100,10 +103,10 @@ make_urban_greening_zone <- function(
 
   # Process built-up areas
   log_message("Processing built-up areas for Urban Greening Zone...")
-  if (!is.null(built_areas_input)) {
+  if (!is.null(built_areas)) {
     log_message("Aligning provided built areas raster to planning units...")
-    built_areas <- elsar::make_normalised_raster(
-      raster_in = built_areas_input,
+    built_areas_processed <- elsar::make_normalised_raster(
+      raster_in = built_areas,
       pus = pus,
       iso3 = iso3,
       rescaled = FALSE,
@@ -111,9 +114,9 @@ make_urban_greening_zone <- function(
     )
   } else {
     assertthat::assert_that(!is.null(lulc_raster),
-      msg = "One of 'built_areas_input', 'lulc_proportions' (with built_area), or 'lulc_raster' must be provided.")
+      msg = "One of 'built_areas', 'lulc_proportions' (with built_area), or 'lulc_raster' must be provided.")
     log_message("Extracting built areas from LULC raster...")
-    built_areas <- elsar::make_normalised_raster(
+    built_areas_processed <- elsar::make_normalised_raster(
       raster_in = lulc_raster,
       pus = pus,
       iso3 = iso3,
@@ -124,8 +127,8 @@ make_urban_greening_zone <- function(
   }
 
   # Apply threshold to create binary zone
-  log_message("Applying built area threshold: {built_area_threshold}")
-  urban_greening_zone <- terra::ifel(built_areas > built_area_threshold, 1, 0)
+  log_message("Applying built area threshold: {built_areas_threshold}")
+  urban_greening_zone <- terra::ifel(built_areas_processed > built_areas_threshold, 1, 0)
 
   # Optionally filter out small patches
   if (filter_patch_size) {
@@ -145,6 +148,12 @@ make_urban_greening_zone <- function(
       datatype = "INT1U"
     )
     log_message("Saved Urban Greening Zone to: {filename}")
+
+    # Also save the region-aligned built-areas input for inspection (mirrors
+    # make_degraded_areas), masked to the planning units (NoData outside).
+    if (exists("built_areas_processed", inherits = FALSE) && inherits(built_areas_processed, "SpatRaster")) {
+      elsar::save_raster(terra::mask(built_areas_processed, pus), glue::glue("{output_path}/built_areas_{iso3}.tif"), datatype = "FLT4S")
+    }
   }
 
   return(urban_greening_zone)


### PR DESCRIPTION
## Summary

Zone builders now expose the region-aligned **intermediate layers** they compute (agriculture, built areas, human pressure, degradation, forest mask, pasturelands, managed forests) by writing them to `output_path` — matching what `make_degraded_areas()` already did — and the zone-function API is harmonised for coherence. Bumped to **0.4.0**.

Pairs with elsar_pipeline PR (its `--emit-intermediate` feature consumes this and enforces `elsar >= 0.4.0`).

## Breaking changes (parameter harmonisation)

- Human-pressure input is `human_pressure` everywhere (was `hii_input` in protect/manage/degraded)
- Raw inputs use bare names — `agricultural_areas`, `built_areas`, `pasturelands`, `managed_forests` (were `*_input`)
- `make_degraded_areas()` takes `iso3`/`pus` (was `country_iso`/`pu`)
- `built_areas_threshold` everywhere (was `built_area_threshold` in restore/urban)
- `make_restore_zone()` uses `filter_patch_size` (was `filter_small_patches`)
- `make_degraded_areas()` output renamed `degraded_areas_{iso3}.tif` (was `restore_zone_`)

Internal `*_processed` variables were introduced where a bare param name would have collided (restore's existing convention). See `NEWS.md`.

## New features

- Each zone builder writes its intermediate inputs to `output_path`, masked to the planning units (NoData outside the study area). `@param output_path` on each function documents exactly which files are written.

## Fixes

- `make_degraded_areas()` saves resampled agriculture/built proportion sidecars as `FLT4S` (were `INT1U`, truncating 0–1 values to zero)
- `make_restore_zone()` always saves the LULC-derived agriculture/built intermediates
- `make_normalised_raster()`: the per-call "not rescaled" `warning()` is now a message; the internal `output_path` writer uses a valid `INT1S` NoData sentinel (`-128`) instead of the out-of-range `255`
- Fixed a broken `make_restore_zone()` roxygen example that used non-existent parameter names

## Verification

- `pkgload::load_all()` clean; all five zone functions smoke-tested with the new names + `output_path` (produce zone + intermediates, no errors)
- No stale parameter references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
